### PR TITLE
Retain height of parent for ConfigrPane to allow scrolling (BL-16159)

### DIFF
--- a/lib/ConfigrPane.tsx
+++ b/lib/ConfigrPane.tsx
@@ -122,6 +122,7 @@ export const ConfigrPane: React.FunctionComponent<
           display: flex;
           flex-direction: row;
           flex: 1;
+          height: 100%; // retain height of parent for possibly scrollable content (BL-16149)
         `}
       >
         <div


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/config-r/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/config-r/24)
<!-- Reviewable:end -->
