### PR TITLE
fix: Tweak comment for preserving height of parent element (BL-16149)

### DIFF
--- a/lib/ConfigrPane.tsx
+++ b/lib/ConfigrPane.tsx
@@ -122,7 +122,7 @@ export const ConfigrPane: React.FunctionComponent<
           display: flex;
           flex-direction: row;
           flex: 1;
-          height: 100%; // retain height of parent for possibly scrollable content (BL-16149)
+          height: 100%; // retain the height of the parent for possibly scrollable content (BL-16149)
         `}
       >
         <div


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/config-r/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/config-r/25)
<!-- Reviewable:end -->
